### PR TITLE
Fix build on linux with musl

### DIFF
--- a/src/qmidinetUdpDevice.cpp
+++ b/src/qmidinetUdpDevice.cpp
@@ -32,6 +32,7 @@ typedef int socklen_t;
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 inline void closesocket(int s) { ::close(s); }
 #endif
 


### PR DESCRIPTION
Build fails for unknown FD_ZERO which is defined in [1]. Somehow musl is again
more picky on this so add #include <sys/select.h>

[1] http://man7.org/linux/man-pages/man2/select.2.html

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>